### PR TITLE
Improve enum case generation for malformed keys

### DIFF
--- a/Sources/BabyBrain/Value.swift
+++ b/Sources/BabyBrain/Value.swift
@@ -376,9 +376,9 @@ extension String {
         if let name = arrayObjectMap[self] {
             return name
         } else {
-            if self.characters.count > 4 && hasSuffix("list") {
+            if self.count > 4 && hasSuffix("list") {
                 return String(characters.dropLast(4))
-            } else if self.characters.count > 1 && hasSuffix("s") {
+            } else if self.count > 1 && hasSuffix("s") {
                 return String(characters.dropLast())
             } else {
                 return self
@@ -387,9 +387,8 @@ extension String {
     }
 
     var detectedType: String {
-        let string = self
-            .replacingOccurrences(of: "-", with: "_")
-            .components(separatedBy: "_")
+        let string =
+            self.components(separatedBy: CharacterSet.alphanumerics.inverted)
             .map({ $0.capitalizingFirstLetter() })
             .joined()
             .capitalizingFirstLetter()


### PR DESCRIPTION
With some JSON sources, I was getting things like:
`case checkConditionTo:false = "CheckConditionTo:false"`
`case visibleDocsFacet categorySourceId = "VisibleDocsFacet category_source_id"`

All non-alphanumerics are now handled, so that we get:
`case checkConditionToFalse = "CheckConditionTo:false"`
`case visibleDocsFacetCategorySourceId = "VisibleDocsFacet category_source_id"`

